### PR TITLE
corrects argument order in find.form

### DIFF
--- a/includes/find.form.inc
+++ b/includes/find.form.inc
@@ -227,11 +227,11 @@ function islandora_find_replace_find_form_validate($form, &$form_state) {
  */
 function islandora_find_replace_find_form_submit($form, &$form_state) {
   $candidates = islandora_find_replace_query($form_state['values']['content_model'],
-    $form_state['values']['namespace'],
     $form_state['values']['collection'],
     $form_state['values']['date_property'],
     $form_state['values']['date_from'],
     $form_state['values']['date_to']
+    $form_state['values']['namespace'],
   );
   
   


### PR DESCRIPTION
While testing out the regex functionality I encountered an error for array to string conversion in line 352 of .module.

In line 230 of find.form the argument order does not match the function definition islandora_find_replace_query in the .module file.