### PR TITLE
Batch revert pr

### DIFF
--- a/includes/log.inc
+++ b/includes/log.inc
@@ -141,14 +141,9 @@ function get_id_from_path() {
  *
  * @param string $id
  * the id of the current log
- * @param string $field
- * field from database, either revisions or dsid
  */
-function get_log_field($id, $field) {
-  if($field != 'revisions' && $field != 'dsid') {
-    throw new Exception("$field is not legal");
-  }
-  $query = db_query("SELECT $field FROM {islandora_find_replace} WHERE id=:logid", array(':logid' => $id));
+function get_log_field($id) {
+  $query = db_query("SELECT * FROM {islandora_find_replace} WHERE id=:logid", array(':logid' => $id));
   return $query;
 }
 
@@ -158,15 +153,16 @@ function get_log_field($id, $field) {
  * @param object $query
  * database object of revisions from batch log
  *
- * @return array $changed
- * array of pids sucessfully changed by batch replace
+ * @return array $log
+ * results of the log as an array with 'revisions' unserialized
  */
-function get_changed_pids_or_revert_version($query, $revert = FALSE) {
-  $result = $query->fetchField();
-  $chunks = unserialize($result);
+function get_log_as_array($query) {
+  $results = (array) $query->fetchAll();
+  $log = (array) $results[0];
+  $chunks = unserialize($log['revisions']);
   if (isset($chunks)) {
-    $changed_or_revert = $revert ? $chunks['success'] : array_keys($chunks['success']);
-    return $changed_or_revert;
+    $log['revisions'] = $chunks['success'];
+    return $log;
   }
 }
 
@@ -176,18 +172,14 @@ function get_changed_pids_or_revert_version($query, $revert = FALSE) {
  */
 function revert_find_replace() {
   $id = get_id_from_path();
-  $query = get_log_field($id,'revisions');
-  $csv = get_changed_pids_or_revert_version($query);
-  $dsid = get_log_field($id, 'dsid');
-  $query_a = get_log_field($id,'revisions');
-  $before_version = get_changed_pids_or_revert_version($query_a, TRUE);
-  $dsid = $dsid->fetchField();
+  $query = get_log_field($id);
+  $log = get_log_as_array($query);
   $operations = array();
-  foreach ($csv as $pid) {
+  foreach ($log['revisions'] as $pid => $change) {
     $operations[] = array(
       'islandora_revert_datastream',
       array(
-        $pid, $dsid, $before_version[$pid]['before'],
+        $pid, $log['dsid'], $change['before'],
       ),
     );
   }

--- a/includes/log.inc
+++ b/includes/log.inc
@@ -90,6 +90,7 @@ function islandora_find_replace_operation_log($find_replace) {
           array('header' => $success_header, 'rows' => $success_rows)),
     ),
   );
+  $output['revert'] = drupal_get_form('revert_form');
   if (!empty($fail_output)) {
     $output['fail'] = array(
       '#type' => 'markup',
@@ -118,4 +119,100 @@ function islandora_find_replace_get_version_id($history, $location) {
     }
   }
   return NULL;
+}
+
+/**
+ * gets the log id form uri
+ *
+ * @return string $id
+ * Id of current page log
+ */
+function get_id_from_path() {
+  $path = explode('/', current_path());
+  $id = '';
+  if (gettype((int)$path['5']) == 'integer') {
+    $id = $path['5'];
+  }
+  return $id;
+}
+
+/**
+ * get record of current log from database
+ *
+ * @param string $id
+ * the id of the current log
+ * @param string $field
+ * field from database, either revisions or dsid
+ */
+function get_log_field($id, $field) {
+  $query = db_query("SELECT $field FROM {islandora_find_replace} WHERE id=:logid", array(':logid' => $id));
+  return $query;
+}
+
+/**
+ * helper to unserialize revised pid log from database query
+ *
+ * @param object $query
+ * database object of revisions from batch log
+ *
+ * @return array $changed
+ * array of pids sucessfully changed by batch replace
+ */
+function get_changed_pids_or_revert_version($query, $revert = FALSE) {
+  $result = $query->fetchField();
+  $chunks = unserialize($result);
+  if (isset($chunks)) {
+    $changed_or_revert = $revert ? $chunks['success'] : array_keys($chunks['success']);
+    return $changed_or_revert;
+  }
+}
+
+
+/**
+ * revert changes made by batch log.
+ */
+function revert_find_replace() {
+  $id = get_id_from_path();
+  $query = get_log_field($id,'revisions');
+  $csv = get_changed_pids_or_revert_version($query);
+  $dsid = get_log_field($id, 'dsid');
+  $query_a = get_log_field($id,'revisions');
+  $before_version = get_changed_pids_or_revert_version($query_a, TRUE);
+  $dsid = $dsid->fetchField();
+  $operations = array();
+  foreach ($csv as $pid) {
+    $operations[] = array(
+      'islandora_revert_datastream',
+      array(
+        $pid, $dsid, $before_version[$pid]['before'],
+      ),
+    );
+  }
+  return $operations;
+}
+
+/**
+ * implements hook_form.
+ */
+function revert_form($form, &$form_state) {
+  $form['revert'] = array(
+    '#type' => 'submit',
+    '#value' => 'Revert this batch',
+  );
+  return $form;
+}
+
+/**
+ * implements hook_form_submit.
+ */
+function revert_form_submit($form, &$form_state) {
+  $batch = array(
+    'operations' => revert_find_replace(),
+    'title' => t('Revert each object'),
+    'init_message' => t('Beginning revert.'),
+    'finished' => 'revert_finished',
+    'progress_message' => t('Processed @current out of @total.'),
+  );
+  batch_set($batch);
+  $form_state['redirect'] = 'admin/islandora/tools/find-replace/find';
 }

--- a/includes/log.inc
+++ b/includes/log.inc
@@ -145,6 +145,9 @@ function get_id_from_path() {
  * field from database, either revisions or dsid
  */
 function get_log_field($id, $field) {
+  if($field != 'revisions' && $field != 'dsid') {
+    throw new Exception("$field is not legal");
+  }
   $query = db_query("SELECT $field FROM {islandora_find_replace} WHERE id=:logid", array(':logid' => $id));
   return $query;
 }

--- a/includes/log.inc
+++ b/includes/log.inc
@@ -122,25 +122,25 @@ function islandora_find_replace_get_version_id($history, $location) {
 }
 
 /**
- * gets the log id form uri
+ * Gets the log id form uri.
  *
- * @return string $id
- * Id of current page log
+ * @return string
+ *   Id of current page log.
  */
 function get_id_from_path() {
   $path = explode('/', current_path());
   $id = '';
-  if (gettype((int)$path['5']) == 'integer') {
+  if (gettype((int) $path['5']) == 'integer') {
     $id = $path['5'];
   }
   return $id;
 }
 
 /**
- * get record of current log from database
+ * Get record of current log from database.
  *
  * @param string $id
- * the id of the current log
+ *   The id of the current log.
  */
 function get_log_field($id) {
   $query = db_query("SELECT * FROM {islandora_find_replace} WHERE id=:logid", array(':logid' => $id));
@@ -148,13 +148,13 @@ function get_log_field($id) {
 }
 
 /**
- * helper to unserialize revised pid log from database query
+ * Helper to unserialize revised pid log from database query.
  *
  * @param object $query
- * database object of revisions from batch log
+ *   Database object of revisions from batch log.
  *
- * @return array $log
- * results of the log as an array with 'revisions' unserialized
+ * @return array
+ *   Results of the log as an array with 'revisions' unserialized.
  */
 function get_log_as_array($query) {
   $results = (array) $query->fetchAll();
@@ -166,9 +166,8 @@ function get_log_as_array($query) {
   }
 }
 
-
 /**
- * revert changes made by batch log.
+ * Revert changes made by batch log.
  */
 function revert_find_replace() {
   $id = get_id_from_path();
@@ -187,7 +186,7 @@ function revert_find_replace() {
 }
 
 /**
- * implements hook_form.
+ * Implements hook_form().
  */
 function revert_form($form, &$form_state) {
   $form['revert'] = array(
@@ -198,7 +197,7 @@ function revert_form($form, &$form_state) {
 }
 
 /**
- * implements hook_form_submit.
+ * Implements hook_form_submit().
  */
 function revert_form_submit($form, &$form_state) {
   $batch = array(

--- a/includes/log.inc
+++ b/includes/log.inc
@@ -204,9 +204,10 @@ function revert_form_submit($form, &$form_state) {
     'operations' => revert_find_replace(),
     'title' => t('Revert each object'),
     'init_message' => t('Beginning revert.'),
-    'finished' => 'revert_finished',
+    'finished' => t('Revert finished'),
     'progress_message' => t('Processed @current out of @total.'),
   );
   batch_set($batch);
   $form_state['redirect'] = 'admin/islandora/tools/find-replace/find';
+  drupal_set_message(t('Revert complete'));
 }

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -89,12 +89,14 @@ function islandora_find_replace_replace_form_submit($form, &$form_state) {
 
   $operations = array();
   foreach ($selected as $select) {
-    $operations[] = array('islandora_find_replace_update_objects', array(
-      $select,
-      $form_state['storage']['find_replace']['dsid'],
-      $form_state['storage']['find_replace']['find'],
-      $form_state['storage']['find_replace']['replacement'],
-      $form_state['storage']['find_replace']['id']),
+    $operations[] = array('islandora_find_replace_update_objects',
+      array(
+        $select,
+        $form_state['storage']['find_replace']['dsid'],
+        $form_state['storage']['find_replace']['find'],
+        $form_state['storage']['find_replace']['replacement'],
+        $form_state['storage']['find_replace']['id'],
+      ),
     );
   }
   $batch = array(

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -364,3 +364,46 @@ function islandora_find_replace_preview($find_replace, $object) {
     drupal_set_message(t('Islandora Pretty Text Diff is required'), 'warning');
   }
 }
+
+/**
+ * Peform reset datastream back one version.
+ *
+ * @param string $pid
+ *   The object pid.
+ * @param string $dsid
+ *   The datastream string.
+ * @param string $revert_version
+ *   Version of the datastream to revert to.
+ * @param string $context
+ *   The target string for the operation.
+ * @param array $context
+ *   Batch context.
+ */
+function islandora_revert_datastream($pid, $dsid, $revert_version, &$context) {
+  $key = datastream_history_match($pid, $dsid, $revert_version);
+  $obj = islandora_object_load($pid);
+  $string = $obj[$dsid][$key]->content;
+  $ds = $obj[$dsid];
+  $ds->setContentFromString($string);
+}
+
+/**
+ * Matches batch record's "before" datastream version.
+ *
+ * @param string $pid
+ *   Object pid.
+ * @param string $dsid
+ *   Datastream identifier.
+ * @param string $revert_version
+ *   Pulled from the batch record, matches the datastream that existed
+ *   before the batch operation was performed.
+ */
+function datastream_history_match($pid, $dsid, $revert_version) {
+  $connection = islandora_get_tuque_connection();
+  $history = $connection->api->m->getDatastreamHistory($pid, $dsid);
+  foreach ($history as $key => $info) {
+    if ($info['dsLocation'] == $revert_version) {
+      return $key;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a feature to the log.inc page to revert datastreams of an entire find and replace batch to the datastream version that existed prior to the batch.

It can be tested by running a replacement on any item, when that item completes, check the item for your change, then hit the "Revert Batch"  button that has been added to the log.inc form, your change should be reverted back to before the module executed the batch.

It will create a take the datastream before the batch and set it as a new datastream. It will always put the datastream version prior to batching as the new datastream, and could overwrite changes that are made outside of a batch.
