### PR TITLE
1kplus pr

### DIFF
--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -68,12 +68,14 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#type' => 'checkbox',
     '#title' => t("If selecting all checkboxes in the table below results in a warning, use this checkbox as an alternate means to 'select all'."),
   );
+
   if (count($options)) {
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Replace String'),
     );
   }
+
   $form['preview'] = array(
     '#type' => 'tableselect',
     '#header' => $header,

--- a/includes/replace.form.inc
+++ b/includes/replace.form.inc
@@ -58,21 +58,40 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
     '#type' => 'markup',
     '#markup' => l(t('Back (New Search)'), 'admin/islandora/tools/find-replace/find'),
   );
-  $form['preview'] = array(
-    '#type' => 'tableselect',
-    '#header' => $header,
-    '#options' => $options,
-    '#empty' => l(t('No matching objects were found. Search again.'),
-      'admin/islandora/tools/find-replace/find'),
+  $count = (string) count(unserialize($find_replace['find_results']));
+  $form['total'] = array(
+    '#type' => 'markup',
+    '#markup' => "<p>Total number of items that match search: $count</p>",
   );
-
+  $php_max_input_vars = ini_get('max_input_vars');
+  $form['process_all'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("If selecting all checkboxes in the table below results in a warning, use this checkbox as an alternate means to 'select all'."),
+  );
   if (count($options)) {
     $form['submit'] = array(
       '#type' => 'submit',
       '#value' => t('Replace String'),
     );
   }
-
+  $form['preview'] = array(
+    '#type' => 'tableselect',
+    '#header' => $header,
+    '#options' => $options,
+    '#empty' => l(t('No matching objects were found. Search again.'),
+      'admin/islandora/tools/find-replace/find'),
+    '#attributes' => array('class' => array('form-checkbox', 'in_tableselect')),
+  );
+  $max_input_vars = array(
+    "maxInputVars" => $php_max_input_vars,
+  );
+  $path = drupal_get_path('module', 'islandora_find_replace') . '/js/islandora_find_replace.js';
+  drupal_add_js(array("islandora_find_replace" => $max_input_vars), "setting");
+  $form['#attached']['js'][] = array(
+    'data' => $path,
+    'type' => 'file',
+    'scope' => 'footer',
+  );
   return $form;
 }
 
@@ -85,7 +104,7 @@ function islandora_find_replace_replace_form($form, &$form_state, $find_replace)
  *   The form state array.
  */
 function islandora_find_replace_replace_form_submit($form, &$form_state) {
-  $selected = array_keys(array_filter($form_state['values']['preview']));
+  $selected = $form_state['values']['process_all'] ? array_keys($form_state['values']['preview']) : array_keys(array_filter($form_state['values']['preview']));
 
   $operations = array();
   foreach ($selected as $select) {

--- a/js/islandora_find_replace.js
+++ b/js/islandora_find_replace.js
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * check if max_input_vars is met on form.
+ */
+
+const maxInputVars = Drupal.settings.islandora_find_replace.maxInputVars;
+const message = `You have selected more checkboxes than this system can handle (max_input_vars: ${maxInputVars}).`;
+const markup = `<div id="console" class="clearfix"><div id="find_replace_warning" class="messages error"><h2 class="element-invisible">Status message</h2><pre>${message}</pre></div></div>`;
+
+(function ($) {
+  Drupal.behaviors.tooManyMessage = {
+    attach: function (context, settings) {
+
+      $.fn.tooManySelected = function () {
+        const selected = this.parent().parent().parent('.selected').length;
+        const messageExists = $('#find_replace_warning').length;
+
+        if (selected < maxInputVars){
+          if (messageExists) {
+            $('#find_replace_warning').remove();
+            $("form").submit(function () {
+              $(this).unbind('submit').submit();
+            });
+          }
+        }
+
+        else {
+          if (!messageExists) {
+            $('#content.clearfix').prepend(markup);
+            $("form").submit(function (e) {
+              e.preventDefault();
+            });
+          }
+        }
+      }
+
+      $('#edit-process-all').change(function () {
+        if (this.checked === true) {
+          $('#find_replace_warning').remove();
+          $('.form-checkbox.in_tableselect').attr('checked', false);
+          $('#selectall.form-checkbox').attr('checked', false);
+          $('.select-all').children().attr('checked', false);
+          $('tbody').children().removeClass('selected');
+        }
+      });
+
+      $('.select-all').change(function () {
+        $('#edit-process-all').attr('checked', false);
+        $('.form-checkbox').tooManySelected();
+      });
+
+      $('.form-checkbox.in_tableselect').change(function () {
+        if (this.click) {
+          $('.form-checkbox').tooManySelected();
+        }
+        if (this.checked === true) {
+          $('#edit-process-all').attr('checked', false);
+        }
+      });
+
+    }
+  }
+}(jQuery));


### PR DESCRIPTION
This pull request allows the replace form to be submitted with more items than PHP max_input_vars would normally allow in the form. It also warns the user when the form has more checkboxes than max_input_vars will allow.

It adds a new checkbox that is mutually exclusive (they turn each other off) with the other form checkboxes.

It can be tested by using a simple collection of 1k items or more, or (easier) changing PHP max_input_vars to a small number for the sake of testing.