### PR TITLE
Issue 13: Wrong XML? not fine, not fine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+.idea/workspace.xml
+.idea/vcs.xml
+.idea/php.xml
+.idea/modules.xml
+.idea/islandora_find_replace.iml
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/$CACHE_FILE$

--- a/includes/log.inc
+++ b/includes/log.inc
@@ -34,42 +34,44 @@ function islandora_find_replace_operation_log($find_replace) {
   }
 
   $success_rows = array();
-  foreach ($revisions['success'] as $pid => $info) {
-    $object = islandora_object_load($pid);
-    if ($object) {
-      $success_rows[$pid] = array(
-        l($object->label, 'islandora/object/' . $object->id,
+  if (isset($revisions['success'])) {
+    foreach ($revisions['success'] as $pid => $info) {
+      $object = islandora_object_load($pid);
+      if ($object) {
+        $success_rows[$pid] = array(
+          l($object->label, 'islandora/object/' . $object->id,
           array('attributes' => array('target' => '_blank'))),
-        l($dsid, 'islandora/object/' . $object->id . '/datastream/' . $dsid . '/version',
+          l($dsid, 'islandora/object/' . $object->id . '/datastream/' . $dsid . '/version',
           array('attributes' => array('target' => '_blank'))),
-      );
-    }
-    else {
-      $orig = $info['before'];
-      $after = $info['after'];
-      $success_rows[$pid] = array(
-        "Object $pid Deleted." ,
-        "Datastream $dsid not available. Before version: $orig to after version: $after, files not available."
-      );
-    }
-    if ($diff_exists) {
-      try {
-        $history = $object->repository->api->m->getDatastreamHistory($object->id, $dsid);
-        $before_version = islandora_find_replace_get_version_id($history, $info['before']);
-        $after_version = islandora_find_replace_get_version_id($history, $info['after']);
-        if (!is_null($before_version) && !is_null($after_version)) {
-          $success_rows[$pid][] = l(
+        );
+      }
+      else {
+        $orig = $info['before'];
+        $after = $info['after'];
+        $success_rows[$pid] = array(
+          "Object $pid Deleted." ,
+          "Datastream $dsid not available. Before version: $orig to after version: $after, files not available."
+        );
+      }
+      if ($diff_exists) {
+        try {
+          $history = $object->repository->api->m->getDatastreamHistory($object->id, $dsid);
+          $before_version = islandora_find_replace_get_version_id($history, $info['before']);
+          $after_version = islandora_find_replace_get_version_id($history, $info['after']);
+          if (!is_null($before_version) && !is_null($after_version)) {
+            $success_rows[$pid][] = l(
             t('View Diff'),
             "islandora/object/{$object->id}/datastream/{$dsid}/diff/{$before_version}/{$after_version}",
             array('attributes' => array('target' => '_blank'))
-          );
+            );
+          }
+          else {
+            $success_rows[$pid][] = t('Not available');
+          }
         }
-        else {
+        catch (Exception $e) {
           $success_rows[$pid][] = t('Not available');
         }
-      }
-      catch (Exception $e) {
-        $success_rows[$pid][] = t('Not available');
       }
     }
   }

--- a/includes/logs.inc
+++ b/includes/logs.inc
@@ -27,9 +27,11 @@ function islandora_find_replace_operation_logs() {
   foreach ($operations as $operation) {
     $objectIDs = '';
     $revisions = unserialize($operation->revisions);
-    if (is_array($revisions) || is_object($revisions)){
-      foreach($revisions['success'] as $key => $value){  
-        $objectIDs = $objectIDs .' <p> ' . $key . '</p>';
+    if (is_array($revisions) || is_object($revisions)) {
+      if (isset($revisions['success'])) {
+        foreach($revisions['success'] as $key => $value){  
+          $objectIDs = $objectIDs .' <p> ' . $key . '</p>';
+        }
       }
     }
     $rows[] = array(

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -253,7 +253,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
         else {
          // XML resulting in this is invalid. Let's  report
           $parms = array('@submissionid' => $id,'@pid' => $pid, '@replace' => $replace, '@search' => $search, '@dsid' => $dsid);
-          $msg = t('XML output resulting of the find and replace operation with id <a href="admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
+          $msg = t('XML output resulting of the find and replace operation with id <a href="/admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
           watchdog('islandora_find_replace', $msg, array( ),WATCHDOG_ERROR);
           // This should stop any futher operation to from happening.
           $context['finished'] = 1;
@@ -266,7 +266,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       }
     }
     catch (Exception $e) {
-      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id <a href="admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
+      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id <a href="/admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
       }
     }
 

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -230,18 +230,41 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       else {
         $content = islandora_find_replace_string_replace($search, $replace, $object[$dsid]->content);
       }
-      $object[$dsid]->setContentFromString($content);
 
-      $location_after = $object[$dsid]->location;
-      // If successful, track the version.
-      if ($location_before != $location_after) {
-        $success = TRUE;
+      // First pass here: if $content ==  $object[$dsid]->content then why do we even bother on adding a version?
+      // Second. Make sure the output, if mime is XML complaint, is a valid XML.
+      if ((trim($content) != trim($object[$dsid]->content)) && !empty(trim($content))) {
+        $valid_format = TRUE;
+        if ($object[$dsid]->mimetype == 'application/xml' || 'text/xml' || 'text/html') {
+          $valid_format = islandora_find_replace_isxml($content);
+        }
+        if ($valid_format) {
+          $object[$dsid]->setContentFromString($content);
+          $location_after = $object[$dsid]->location;
+          // If successful, track the version.
+          if ($location_before != $location_after) {
+            $success = TRUE;
+          }
+        }
+        else {
+         // XML resulting in this is invalid. Let's  report
+          $parms = array('@submissionid' => $id,'@pid' => $pid, '@replace' => $replace, '@search' => $search, '@dsid' => $dsid);
+          $msg = t('XML output resulting of the find and replace operation of submission id @submissionid for PID @pid when generating datastreams for Object with PID @pid and Datastream ID @dsid is invalid. Cancelling the whole batch.', $parms);
+          watchdog('islandora_find_replace', $msg, array( ),WATCHDOG_ERROR);
+          // This should stop any futher operation to from happening.
+          $context['finished'] = 1;
+          drupal_set_message(t('Find and Replaced Batch was suspended because one replace operation leads to a no valid XML. Please check your logs and or/replace your search & replacement patterns.'));
+        }
+      }
+      else {
+        $success = NULL;
       }
     }
     catch (Exception $e) {
-
+      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id @submissionid for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
+      }
     }
-  }
+
 
   $find_replace = islandora_find_replace_load($id);
   $revisions = unserialize($find_replace['revisions']);
@@ -348,10 +371,6 @@ function islandora_find_replace_query($model, $collection = FALSE, $date_propert
     $condition .= 'fr:isMemberOfCollection <info:fedora/' . $collection . '> ; ';
   }
 
-  if ($namespace) {
-    $condition .= 'FILTER(REGEX(STR(?object), "^info:fedora/' . $namespace . ':"))';
-  }
-
   if ($date_property) {
     $from = _islandora_find_replace_timestamp_from_form_date($date_from);
     $to = _islandora_find_replace_timestamp_from_form_date($date_to, FALSE);
@@ -362,6 +381,11 @@ function islandora_find_replace_query($model, $collection = FALSE, $date_propert
     $condition .= $date_query . ' ?date
       FILTER ( ?date >= xsd:dateTime("' . $from . '") && ?date <= xsd:dateTime("' . $to . '"))';
   }
+
+  if ($namespace) {
+    $condition .= 'FILTER (REGEX( STR(?object), "^info:fedora/' . $namespace . ':", "i"))';
+  }
+
   $tuque = islandora_get_tuque_connection();
   $query = "PREFIX fm: <" . FEDORA_MODEL_URI . ">
             PREFIX fr: <" . FEDORA_RELS_EXT_URI . ">
@@ -391,8 +415,8 @@ function islandora_find_replace_query($model, $collection = FALSE, $date_propert
  * @param FedoraObject $object
  *   The Fedora object to preview the change for.
  *
- * @return array
- *   Rendered diff from the Islandora Pretty Text Diff module.
+ * @return array|boolean
+ *   Rendered diff from the Islandora Pretty Text Diff module or FALSE
  */
 function islandora_find_replace_preview($find_replace, $object) {
   if (module_exists('islandora_pretty_text_diff')) {
@@ -424,5 +448,17 @@ function islandora_find_replace_preview($find_replace, $object) {
   }
   else {
     drupal_set_message(t('Islandora Pretty Text Diff is required'), 'warning');
+    return FALSE;
+  }
+  return FALSE;
+}
+
+
+function islandora_find_replace_isxml($xml) {
+  $doc = @simplexml_load_string($xml);
+  if ($doc) {
+    return true; //valid
+  } else {
+    return false; //not valid
   }
 }

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -254,11 +254,11 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
          // XML resulting in this is invalid. Let's  report
           $parms = array('@submissionid' => $id,'@pid' => $pid, '@replace' => $replace, '@search' => $search, '@dsid' => $dsid);
           $msg = t('XML output resulting of the find and replace operation with id <a href="/admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
-          watchdog('islandora_find_replace', $msg, array( ),WATCHDOG_ERROR);
+          watchdog('islandora_find_replace', $msg, array( ), WATCHDOG_ERROR);
           // This should stop any futher operation to from happening.
           $context['finished'] = 1;
           $context['results']['totalfailure'] = TRUE;
-          drupal_set_message(t('This find and Replaced Batch update was suspended because one replace operation leads to an invalid XML. Please check your logs and or/replace your search & replacement patterns.'));
+          drupal_set_message(t('This find and Replaced Batch update was suspended because one replace operation leads to an invalid XML. Please check your logs and or/replace your search & replacement patterns.'),'warning');
         }
       }
       else {
@@ -266,7 +266,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       }
     }
     catch (Exception $e) {
-      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id <a href="/admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
+      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id <a href="/admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid), WATCHDOG_ERROR);
       }
     }
 
@@ -307,7 +307,10 @@ function islandora_find_replace_update_complete($success, $results, $operations)
     ->fields(array('state' => 'complete'))
     ->condition('id', $results['submission_id'])
     ->execute();
-  drupal_set_message(t('Find and Replace complete!'));
+  
+  if (!isset($results['totalfailure'])) { 
+    drupal_set_message(t('Find and Replace Batch Operations complete.'));
+  }
 }
 
 /**
@@ -405,6 +408,7 @@ function islandora_find_replace_query($model, $collection = FALSE, $date_propert
               }
            }";
   $results = array();
+
   $query_results = $tuque->repository->ri->sparqlQuery($query, 'unlimited');
   foreach ($query_results as $result) {
     $results[] = array('label' => $result['label']['value'], 'object' => $result['object']['value']);

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -219,8 +219,12 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
   if (!isset($context['results']['submission_id'])) {
     $context['results']['submission_id'] = $id;
   }
-  $object = islandora_object_load($pid);
+  
   $success = FALSE;
+  if (!isset($context['results']['totalfailure'])) {
+    
+  $object = islandora_object_load($pid);
+ 
   if (isset($object[$dsid]) && islandora_datastream_access(ISLANDORA_METADATA_EDIT, $object[$dsid])) {
     try {
       $location_before = $object[$dsid]->location;
@@ -235,7 +239,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       // Second. Make sure the output, if mime is XML complaint, is a valid XML.
       if ((trim($content) != trim($object[$dsid]->content)) && !empty(trim($content))) {
         $valid_format = TRUE;
-        if ($object[$dsid]->mimetype == 'application/xml' || 'text/xml' || 'text/html') {
+        if (in_array($object[$dsid]->mimetype, array('application/xml','text/xml', 'text/html'))) {
           $valid_format = islandora_find_replace_isxml($content);
         }
         if ($valid_format) {
@@ -249,11 +253,12 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
         else {
          // XML resulting in this is invalid. Let's  report
           $parms = array('@submissionid' => $id,'@pid' => $pid, '@replace' => $replace, '@search' => $search, '@dsid' => $dsid);
-          $msg = t('XML output resulting of the find and replace operation of submission id @submissionid for PID @pid when generating datastreams for Object with PID @pid and Datastream ID @dsid is invalid. Cancelling the whole batch.', $parms);
+          $msg = t('XML output resulting of the find and replace operation with id @submissionid for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
           watchdog('islandora_find_replace', $msg, array( ),WATCHDOG_ERROR);
           // This should stop any futher operation to from happening.
           $context['finished'] = 1;
-          drupal_set_message(t('Find and Replaced Batch was suspended because one replace operation leads to a no valid XML. Please check your logs and or/replace your search & replacement patterns.'));
+          $context['results']['totalfailure'] = TRUE;
+          drupal_set_message(t('This find and Replaced Batch update was suspended because one replace operation leads to an invalid XML. Please check your logs and or/replace your search & replacement patterns.'));
         }
       }
       else {
@@ -265,7 +270,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       }
     }
 
-
+  }
   $find_replace = islandora_find_replace_load($id);
   $revisions = unserialize($find_replace['revisions']);
 

--- a/islandora_find_replace.module
+++ b/islandora_find_replace.module
@@ -253,7 +253,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
         else {
          // XML resulting in this is invalid. Let's  report
           $parms = array('@submissionid' => $id,'@pid' => $pid, '@replace' => $replace, '@search' => $search, '@dsid' => $dsid);
-          $msg = t('XML output resulting of the find and replace operation with id @submissionid for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
+          $msg = t('XML output resulting of the find and replace operation with id <a href="admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream @dsid is invalid. Cancelling the whole batch.', $parms);
           watchdog('islandora_find_replace', $msg, array( ),WATCHDOG_ERROR);
           // This should stop any futher operation to from happening.
           $context['finished'] = 1;
@@ -266,7 +266,7 @@ function islandora_find_replace_update_objects($pid, $dsid, $search, $replace, $
       }
     }
     catch (Exception $e) {
-      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id @submissionid for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
+      watchdog('islandora_find_replace', 'An exception ocurred during find and replace with submission id <a href="admin/islandora/tools/find-replace/log/@submissionid">@submissionid</a> for Object with PID @pid and Datastream ID @dsid ', array('@submissionid' => $id, '@pid' => $pid, '@dsid' => $dsid),WATCHDOG_ERROR);
       }
     }
 


### PR DESCRIPTION
# What does this pull solve?
See #13 and also #12 (hopefully)

Basically it checks if the resulting find and replace operation against a given XML data stream ends in a valid (simply valid in terms of an actual XML that can be parsed, we are not validating if its MODS, etc). I checked the whole islandora code base and there IS NOT A SINGLE check anywhere when dealing with XML. Its terrible. All depends on if Fedora takes or not the file and if it dies/throws errors or not. So disappointed..

How does this work?

1.- We check first here if there is an actual change. I mean why do we need to update a data stream if nothing is going to be changed?
2.- if that passes, we check the mime-type of the data stream, if its text/xml, application/xml or text/html we simply, silenty load it via the simple xml class. If it fails we assume (correctly) it's wrong. This applies to things like "hey" i want to add an `&` or a  on closing tag. 

3.- If it fails we add a new key to the batch context named  "total failure" and assume that one bad replacement will/could lead to the same in the rest and stop processing but skipping further attempts. that is the way. If your pattern can lead to wrong XML then change it.

How to test? Git checkout, git pull, choose a collection you care little about, try find any closing tag and replace it by an "&". Do it, should start and finish quick and give you a message and a list of failed replacements that has all the ones that matched originally in the list. Also there will be in the Reports/logs entries about the error with a link to that find and replace log id.

Finally it moves the namespace check to the end of the filter chain. Have not tested that but at least? it does not fail. Can anyone see if it is working fine?

@bondjimbond @flummingbird maybe there is interest there to test this? Not sure how many of you are still using this, but this makes this module wayyyyyyy safer.


